### PR TITLE
Actualización Tailwind y migración inicial a TypeScript

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -6,17 +6,14 @@
 
 - Frontend: React 18
 - Base: [Material Dashboard React](https://github.com/creativetimofficial/material-dashboard-react)
-
   - Versión: 2.2.0
   - Librerías:
-
     - `@mui/material@5.12.3`
     - `@mui/icons-material@5.11.16`
 
 - Kanban: `@lourenci/react-kanban`
 - Drag Scroll: componente custom propio
 - CSS Customizado:
-
   - custom-scrollbar.css
   - custom-kanban.css
 
@@ -46,12 +43,10 @@ Esto es clave para garantizar continuidad y coherencia en el trabajo, tanto para
 
 - Usa `react-kanban`
 - Responsive:
-
   - Se adapta al ancho visible del dashboard
   - Scroll horizontal si hay muchas columnas
 
 - Drag scroll implementado:
-
   - Wrapper custom `DragScrollWrapper`
   - Evita conflictos con drag & drop interno del Kanban
 
@@ -63,7 +58,6 @@ Archivo: `src/components/DragScrollWrapper.jsx`
 
 - Permite scroll horizontal arrastrando con el mouse
 - Excluye drag en:
-
   - `.react-kanban-column-header`
   - `.react-kanban-card`
 
@@ -86,14 +80,11 @@ Archivo: `src/components/DragScrollWrapper.jsx`
 ### custom-kanban.css
 
 - Integra el diseño de Kanban con Material Dashboard React:
-
   - Columnas:
-
     - fondo gris claro
     - color de título primario (#5e72e4)
 
   - Tarjetas:
-
     - fondo blanco
     - bordes suaves
     - tipografía Roboto
@@ -117,12 +108,10 @@ Archivo: `src/components/DragScrollWrapper.jsx`
 ## **Pendiente**
 
 - Integrar Firebase:
-
   - Auth
   - Firestore → reemplazar datos mock del Kanban
 
 - Reportes:
-
   - Charts (Chart.js o Recharts)
   - Exportación PDF/Excel
 
@@ -134,15 +123,12 @@ Archivo: `src/components/DragScrollWrapper.jsx`
 ## **Notas de implementación**
 
 - Para el Kanban:
-
   - No meterlo en `Card` → usar `DashboardLayout` y `MDBox`
 
 - Drag scroll:
-
   - Implementado manualmente, sin librerías externas
 
 - Prettier:
-
   - Ejecutar:
 
     ```
@@ -184,3 +170,10 @@ npm start
 - Se instaló el componente `sidebar` de shadcn/ui en `src/components/ui`.
 - Se actualizó `src/index.js` para importar `index.css`.
 - Ejecutar `npm install` después de clonar el repositorio para instalar las nuevas dependencias.
+
+## 2025-07-17 Migración inicial a TypeScript y pruebas
+- Se actualizó `tailwind.config.js` para que Tailwind escanee `app-vite/src`.
+- `DragScrollWrapper.jsx` y `views/KanbanBoard.jsx` se migraron a TypeScript.
+- Se añadió configuración de Vitest (`vitest.config.ts`) y un test básico de `DragScrollWrapper`.
+- Se agregaron dependencias de testing en `app-vite/package.json` (`vitest`, `@testing-library/react`, `@testing-library/jest-dom`, `jsdom`).
+- Ejecutar `npm install` y `npm run test` dentro de `app-vite` para validar.

--- a/app-vite/package.json
+++ b/app-vite/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -15,6 +16,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
@@ -22,8 +25,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^26.1.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/app-vite/src/components/DragScrollWrapper.tsx
+++ b/app-vite/src/components/DragScrollWrapper.tsx
@@ -1,5 +1,8 @@
 import React, { useRef } from "react";
-import PropTypes from "prop-types";
+
+interface DragScrollWrapperProps {
+  children: React.ReactNode;
+}
 
 /**
  * DragScrollWrapper
@@ -9,19 +12,19 @@ import PropTypes from "prop-types";
  * @param {object} props - Children dentro del wrapper.
  * @returns JSX.Element
  */
-export default function DragScrollWrapper({ children }) {
-  const scrollRef = useRef(null);
+export default function DragScrollWrapper({ children }: DragScrollWrapperProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   let isDown = false;
-  let startX;
-  let scrollLeft;
+  let startX: number;
+  let scrollLeft: number;
 
-  const isExcluded = (target) => {
+  const isExcluded = (target: HTMLElement) => {
     // Devuelve true si hiciste click sobre columna o card
     return target.closest(".react-kanban-column-header") || target.closest(".react-kanban-card");
   };
 
-  const handleMouseDown = (e) => {
-    if (isExcluded(e.target)) {
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (isExcluded(e.target as HTMLElement)) {
       // No activar drag-scroll si hiciste click sobre columna/card
       return;
     }
@@ -41,7 +44,7 @@ export default function DragScrollWrapper({ children }) {
     scrollRef.current.classList.remove("active");
   };
 
-  const handleMouseMove = (e) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!isDown) return;
     e.preventDefault();
     const x = e.pageX - scrollRef.current.offsetLeft;
@@ -66,7 +69,3 @@ export default function DragScrollWrapper({ children }) {
     </div>
   );
 }
-
-DragScrollWrapper.propTypes = {
-  children: PropTypes.node.isRequired,
-};

--- a/app-vite/src/components/__tests__/DragScrollWrapper.test.tsx
+++ b/app-vite/src/components/__tests__/DragScrollWrapper.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DragScrollWrapper from "../DragScrollWrapper";
+import "@testing-library/jest-dom/vitest";
+
+/**
+ * Pruebas básicas para DragScrollWrapper
+ */
+
+describe("DragScrollWrapper", () => {
+  it("renderiza el contenido hijo", () => {
+    render(
+      <DragScrollWrapper>
+        <span>Contenido</span>
+      </DragScrollWrapper>
+    );
+
+    expect(screen.getByText("Contenido")).toBeInTheDocument();
+  });
+});

--- a/app-vite/src/routes.js
+++ b/app-vite/src/routes.js
@@ -44,7 +44,7 @@ import Notifications from "./layouts/notifications";
 import Profile from "./layouts/profile";
 import SignIn from "./layouts/authentication/sign-in";
 import SignUp from "./layouts/authentication/sign-up";
-import KanbanBoard from "./views/KanbanBoard.jsx";
+import KanbanBoard from "./views/KanbanBoard";
 
 // @mui icons
 import Icon from "@mui/material/Icon";

--- a/app-vite/src/views/KanbanBoard.tsx
+++ b/app-vite/src/views/KanbanBoard.tsx
@@ -1,4 +1,20 @@
 import React from "react";
+
+interface Card {
+  id: number;
+  title: string;
+  description?: string;
+}
+
+interface Column {
+  id: number;
+  title: string;
+  cards: Card[];
+}
+
+interface BoardType {
+  columns: Column[];
+}
 import DashboardLayout from "examples/LayoutContainers/DashboardLayout";
 import DashboardNavbar from "examples/Navbars/DashboardNavbar";
 import MDBox from "../components/MDBox";
@@ -9,7 +25,7 @@ import "@lourenci/react-kanban/dist/styles.css";
 import "assets/css/custom-scrollbar.css";
 
 export default function KanbanBoard() {
-  const board = {
+  const board: BoardType = {
     columns: [
       {
         id: 1,

--- a/app-vite/vitest.config.ts
+++ b/app-vite/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+  content: ["./app-vite/src/**/*.{js,jsx,ts,tsx}", "./app-vite/index.html"],
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## Resumen
- actualizar `tailwind.config.js` para apuntar a `app-vite/src`
- migrar `DragScrollWrapper` y `KanbanBoard` a TypeScript
- añadir configuración y dependencias de Vitest
- crear prueba básica para `DragScrollWrapper`
- documentar cambios en `agents.md`

## Testing
- `npm install` dentro de `app-vite`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6878b575c51c8328be72c250d81f570f